### PR TITLE
/lib/ld-linux-x86-64.so.2 link

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -15,7 +15,7 @@ subpackages="$pkgname-bin $pkgname-i18n"
 triggers="$pkgname-bin.trigger=/lib:/usr/lib:/usr/glibc-compat/lib"
 
 package() {
-  mkdir -p "$pkgdir/lib64" "$pkgdir/usr/glibc-compat/lib/locale" "$pkgdir"/etc
+  mkdir -p "$pkgdir/lib" "$pkgdir/lib64" "$pkgdir/usr/glibc-compat/lib/locale" "$pkgdir"/etc
   cp -a "$srcdir"/usr "$pkgdir"
   cp "$srcdir"/nsswitch.conf "$pkgdir"/etc/nsswitch.conf
   cp "$srcdir"/ld.so.conf "$pkgdir"/usr/glibc-compat/etc/ld.so.conf
@@ -29,6 +29,7 @@ package() {
   rm -rf "$pkgdir"/usr/glibc-compat/include
   rm -rf "$pkgdir"/usr/glibc-compat/share
   rm -rf "$pkgdir"/usr/glibc-compat/var
+  ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 ${pkgdir}/lib/ld-linux-x86-64.so.2
   ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 ${pkgdir}/lib64/ld-linux-x86-64.so.2
   ln -s /usr/glibc-compat/etc/ld.so.cache ${pkgdir}/etc/ld.so.cache
 }
@@ -49,4 +50,4 @@ i18n() {
 
 md5sums="5950e0b8f0bae4af07b405c7b1f6e194  glibc-bin-2.23-0-x86_64.tar.gz
 5be984273de4203318c9c3fb0d4e9d2b  nsswitch.conf
-b4a846d17bde75e47976d972c4e067a5  ld.so.conf"
+0484678534996fdddef848544bd1a12d  ld.so.conf"

--- a/ld.so.conf
+++ b/ld.so.conf
@@ -1,3 +1,6 @@
+# libc default configuration
+/usr/local/lib
+
 /usr/glibc-compat/lib
 /usr/lib
 /lib


### PR DESCRIPTION
Fixes issues with musl built openjdk. Thanks to @frol, the solution has been found without actually breaking the glibc package :+1: 