### PR TITLE
Bump upstream glibc version to v2.25

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 
 pkgname="glibc"
-pkgver="2.24"
+pkgver="2.25"
 _pkgrel="0"
 pkgrel="0"
 pkgdesc="GNU C Library compatibility layer"
@@ -48,12 +48,12 @@ i18n() {
   cp -a "$srcdir"/usr/glibc-compat/share "$subpkgdir"/usr/glibc-compat
 }
 
-md5sums="5689ccad01298259ccbdf7888ca3bf90  glibc-bin-2.24-0-x86_64.tar.gz
+md5sums="f3f189a024519a29a35313c6957064a9  glibc-bin-2.25-0-x86_64.tar.gz
 5be984273de4203318c9c3fb0d4e9d2b  nsswitch.conf
 0484678534996fdddef848544bd1a12d  ld.so.conf"
-sha256sums="f488ff2f9156d486ef1fdae908e63cd112cec721fb6a250fd8e41586396373b8  glibc-bin-2.24-0-x86_64.tar.gz
+sha256sums="47a3aab527fb1511d6fb3c01793bab1ab600970d5b8b87c8d452c90a67027e99  glibc-bin-2.25-0-x86_64.tar.gz
 3be94785355b4b363d1268f133e198323441eafa6017b2b1fed32ae279d685c7  nsswitch.conf
 f8eec838bace59c29a5dc04550f60e3c7ba9f3a9df7b14dae36349ad90152e00  ld.so.conf"
-sha512sums="15491626d764ec93eda2b88fa50f8d125a3d1d047afb28495cd6042330718880297c38b6d71cb07d18238d4153fd07185e79005f71c7b15315a2b5f301a4ae95  glibc-bin-2.24-0-x86_64.tar.gz
+sha512sums="14b5d923b375dd34656554d61ce641920f8d11049a9c2ea48eadb3febb3c700105153f0e50f88793d67cde8e40f0f7848928e6c74cec344b64cbd4f866578a05  glibc-bin-2.25-0-x86_64.tar.gz
 478bdd9f7da9e6453cca91ce0bd20eec031e7424e967696eb3947e3f21aa86067aaf614784b89a117279d8a939174498210eaaa2f277d3942d1ca7b4809d4b7e  nsswitch.conf
 2912f254f8eceed1f384a1035ad0f42f5506c609ec08c361e2c0093506724a6114732db1c67171c8561f25893c0dd5c0c1d62e8a726712216d9b45973585c9f7  ld.so.conf"

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ The current installation method for these packages is to pull them in using `wge
 
     apk --no-cache add ca-certificates
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.24-r0/glibc-2.24-r0.apk
-    apk add glibc-2.24-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk
+    apk add glibc-2.25-r0.apk
 
 ## Locales
 
 You will need to generate your locale if you would like to use a specific one for your glibc application. You can do this by installing the `glibc-i18n` package and generating a locale using the `localedef` binary. An example for en_US.UTF-8 would be:
 
-    apk add glibc-bin-2.24-r0.apk glibc-i18n-2.24-r0.apk
+    apk add glibc-bin-2.25-r0.apk glibc-i18n-2.25-r0.apk
     /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8


### PR DESCRIPTION
💁  These changes bump the version of glibc to 2.25.

Closes #35