### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See the [releases page](https://github.com/sgerrand/alpine-pkg-glibc/releases) f
 
 The current installation method for these packages is to pull them in using `wget` or `curl` and install the local file with `apk`:
 
-    apk --no-cache add ca-certificates
+    apk --no-cache add ca-certificates wget
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub
     wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk
     apk add glibc-2.25-r0.apk


### PR DESCRIPTION
Add openssl as a dependency for ssl_helper

This will fix the problem:
```ash
/ # wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub
wget: can't execute 'ssl_helper': No such file or directory
wget: error getting response: Connection reset by peer
```