### PR TITLE
Update glibc version to 2.26

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 
 pkgname="glibc"
-pkgver="2.25"
+pkgver="2.26"
 _pkgrel="0"
-pkgrel="1"
+pkgrel="0"
 pkgdesc="GNU C Library compatibility layer"
 arch="x86_64"
 url="https://github.com/sgerrand/alpine-pkg-glibc"
@@ -46,12 +46,6 @@ i18n() {
   cp -a "$srcdir"/usr/glibc-compat/share "$subpkgdir"/usr/glibc-compat
 }
 
-md5sums="f3f189a024519a29a35313c6957064a9  glibc-bin-2.25-0-x86_64.tar.gz
-5be984273de4203318c9c3fb0d4e9d2b  nsswitch.conf
-0484678534996fdddef848544bd1a12d  ld.so.conf"
-sha256sums="47a3aab527fb1511d6fb3c01793bab1ab600970d5b8b87c8d452c90a67027e99  glibc-bin-2.25-0-x86_64.tar.gz
-3be94785355b4b363d1268f133e198323441eafa6017b2b1fed32ae279d685c7  nsswitch.conf
-f8eec838bace59c29a5dc04550f60e3c7ba9f3a9df7b14dae36349ad90152e00  ld.so.conf"
-sha512sums="14b5d923b375dd34656554d61ce641920f8d11049a9c2ea48eadb3febb3c700105153f0e50f88793d67cde8e40f0f7848928e6c74cec344b64cbd4f866578a05  glibc-bin-2.25-0-x86_64.tar.gz
+sha512sums="97870996e0d8da9ff5a01f4393b3a9789547e31f22096c9a53065f61e8b39c74531081a012ca4fc2cb76ffb23a7d7017128000e2a451ac9ce33704c3378f3c21  glibc-bin-2.26-0-x86_64.tar.gz
 478bdd9f7da9e6453cca91ce0bd20eec031e7424e967696eb3947e3f21aa86067aaf614784b89a117279d8a939174498210eaaa2f277d3942d1ca7b4809d4b7e  nsswitch.conf
 2912f254f8eceed1f384a1035ad0f42f5506c609ec08c361e2c0093506724a6114732db1c67171c8561f25893c0dd5c0c1d62e8a726712216d9b45973585c9f7  ld.so.conf"


### PR DESCRIPTION
💁  These changes release version 2.24 of the glibc package.