### PR TITLE
Reference 2.26 installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ The current installation method for these packages is to pull them in using `wge
 
     apk --no-cache add ca-certificates wget
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk
-    apk add glibc-2.25-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.26-r0/glibc-2.26-r0.apk
+    apk add glibc-2.26-r0.apk
 
 ## Locales
 
 You will need to generate your locale if you would like to use a specific one for your glibc application. You can do this by installing the `glibc-i18n` package and generating a locale using the `localedef` binary. An example for en_US.UTF-8 would be:
 
-    apk add glibc-bin-2.25-r0.apk glibc-i18n-2.25-r0.apk
+    apk add glibc-bin-2.26-r0.apk glibc-i18n-2.26-r0.apk
     /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8


### PR DESCRIPTION
💁 I missed updating the installation documentation in #64. This change corrects that.