### PR TITLE
Bump glibc version to 2.27

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 
 pkgname="glibc"
-pkgver="2.26"
+pkgver="2.27"
 _pkgrel="0"
 pkgrel="0"
 pkgdesc="GNU C Library compatibility layer"
@@ -46,6 +46,6 @@ i18n() {
   cp -a "$srcdir"/usr/glibc-compat/share "$subpkgdir"/usr/glibc-compat
 }
 
-sha512sums="97870996e0d8da9ff5a01f4393b3a9789547e31f22096c9a53065f61e8b39c74531081a012ca4fc2cb76ffb23a7d7017128000e2a451ac9ce33704c3378f3c21  glibc-bin-2.26-0-x86_64.tar.gz
+sha512sums="a9f229dbb2ee27f74397f979f7b49e713c6c926b7fe948d95139ce16a8dcc3a94096be2c8d5037df92e798cc1388b4b169bfc8062dce4614155188efe67abaaa  glibc-bin-2.27-0-x86_64.tar.gz
 478bdd9f7da9e6453cca91ce0bd20eec031e7424e967696eb3947e3f21aa86067aaf614784b89a117279d8a939174498210eaaa2f277d3942d1ca7b4809d4b7e  nsswitch.conf
 2912f254f8eceed1f384a1035ad0f42f5506c609ec08c361e2c0093506724a6114732db1c67171c8561f25893c0dd5c0c1d62e8a726712216d9b45973585c9f7  ld.so.conf"

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ The current installation method for these packages is to pull them in using `wge
 
     apk --no-cache add ca-certificates wget
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.26-r0/glibc-2.26-r0.apk
-    apk add glibc-2.26-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.27-r0/glibc-2.27-r0.apk
+    apk add glibc-2.27-r0.apk
 
 ## Locales
 
 You will need to generate your locale if you would like to use a specific one for your glibc application. You can do this by installing the `glibc-i18n` package and generating a locale using the `localedef` binary. An example for en_US.UTF-8 would be:
 
-    apk add glibc-bin-2.26-r0.apk glibc-i18n-2.26-r0.apk
+    apk add glibc-bin-2.27-r0.apk glibc-i18n-2.27-r0.apk
     /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8


### PR DESCRIPTION
💁  Releases version 2.27 of the [glibc](https://www.gnu.org/software/libc/) package.