### PR TITLE
Update CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # alpine-pkg-glibc
 
-[![CircleCI](https://img.shields.io/circleci/project/sgerrand/alpine-pkg-glibc/master.svg)](https://circleci.com/gh/sgerrand/alpine-pkg-glibc) ![x86_64](https://img.shields.io/badge/x86__64-supported-brightgreen.svg)
+[![CircleCI](https://circleci.com/gh/sgerrand/alpine-pkg-glibc/tree/master.svg?style=svg)](https://circleci.com/gh/sgerrand/alpine-pkg-glibc/tree/master) ![x86_64](https://img.shields.io/badge/x86__64-supported-brightgreen.svg)
 
 This is the GNU C library as a Alpine Linux package to run binaries linked against `glibc`. This package utilizes a custom built glibc binary based on the vanilla glibc source. Built binary artifacts come from https://github.com/sgerrand/docker-glibc-builder.
 


### PR DESCRIPTION
💁 It appears that CircleCI have changed the location of their build status images. This change resolves that.