### PR TITLE
glibc v2.29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,16 +33,16 @@ jobs:
       - run:
           name: Create Docker volumes
           command: |
-            docker create --name input --volume /home/builder/package alpine:3.8 /bin/true
+            docker create --name input --volume /home/builder/package alpine:3.9 /bin/true
             docker cp . input:/home/builder/package/
-            docker create --name output --volume /packages alpine:3.8 /bin/true
+            docker create --name output --volume /packages alpine:3.9 /bin/true
             docker cp sgerrand.rsa.pub output:/packages/
       - run:
           name: Build packages
-          command: docker run --env RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" --env RSA_PRIVATE_KEY_NAME="sgerrand.rsa" --volumes-from input --volumes-from output sgerrand/alpine-abuild:v7
+          command: docker run --env RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" --env RSA_PRIVATE_KEY_NAME="sgerrand.rsa" --volumes-from input --volumes-from output sgerrand/alpine-abuild:3.9
       - run:
           name: Test package installation
-          command: docker run --volumes-from output alpine:3.8 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
+          command: docker run --volumes-from output alpine:3.9 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
       - run:
           name: Extract packages
           command: |

--- a/APKBUILD
+++ b/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 
 pkgname="glibc"
-pkgver="2.28"
+pkgver="2.29"
 _pkgrel="0"
 pkgrel="0"
 pkgdesc="GNU C Library compatibility layer"
@@ -46,6 +46,6 @@ i18n() {
   cp -a "$srcdir"/usr/glibc-compat/share "$subpkgdir"/usr/glibc-compat
 }
 
-sha512sums="77403b5c28d0f251d4855dd1de2f5d46f20b32ed63792c97fbd409cb6c57b711c0a5471bb68aba1d8a3fe0df88b64e9c9e14b1d5235734c84c9758dd95b9c6c7  glibc-bin-2.28-0-x86_64.tar.gz
+sha512sums="5e7c03f65f1f483bfb643a7d4a4030380d2926734bda35823fed056161a789233d34141e15570e573bff3ea41c477848080f0daed2583d2f076e2857ff6ef3fb  glibc-bin-2.29-0-x86_64.tar.gz
 478bdd9f7da9e6453cca91ce0bd20eec031e7424e967696eb3947e3f21aa86067aaf614784b89a117279d8a939174498210eaaa2f277d3942d1ca7b4809d4b7e  nsswitch.conf
 2912f254f8eceed1f384a1035ad0f42f5506c609ec08c361e2c0093506724a6114732db1c67171c8561f25893c0dd5c0c1d62e8a726712216d9b45973585c9f7  ld.so.conf"

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ The current installation method for these packages is to pull them in using `wge
 
     apk --no-cache add ca-certificates wget
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk
-    apk add glibc-2.28-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk
+    apk add glibc-2.29-r0.apk
 
 ### Please Note
 
@@ -27,5 +27,5 @@ Any previous reference to `https://raw.githubusercontent.com/sgerrand/alpine-pkg
 
 You will need to generate your locale if you would like to use a specific one for your glibc application. You can do this by installing the `glibc-i18n` package and generating a locale using the `localedef` binary. An example for en_US.UTF-8 would be:
 
-    apk add glibc-bin-2.28-r0.apk glibc-i18n-2.28-r0.apk
+    apk add glibc-bin-2.29-r0.apk glibc-i18n-2.29-r0.apk
     /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8


### PR DESCRIPTION
💁 Releases [version 2.29](https://sourceware.org/ml/libc-announce/2019/msg00000.html) of the [GNU C Library](https://www.gnu.org/software/libc/) package.

Closes #105 