### PR TITLE
Fix typo: localdef -> localedef

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the GNU C library as a Alpine Linux package to run binaries linked again
 
 ## Releases
 
-See the [releases page](https://github.com/sgerrand/alpine-pkg-glibc/releases) for the latest download links. If you are using tools like `localdef` you will need the `glibc-bin` and `glibc-i18n` packages in addition to the `glibc` package.
+See the [releases page](https://github.com/sgerrand/alpine-pkg-glibc/releases) for the latest download links. If you are using tools like `localedef` you will need the `glibc-bin` and `glibc-i18n` packages in addition to the `glibc` package.
 
 ## Installing
 


### PR DESCRIPTION
I believe there is a minor typo in the readme, since the binary's name is actually `localedef` and not `localdef`.