### PR TITLE
Update package dependencies 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,16 +33,16 @@ jobs:
       - run:
           name: Create Docker volumes
           command: |
-            docker create --name input --volume /home/builder/package alpine:3.9 /bin/true
+            docker create --name input --volume /home/builder/package alpine:3.10 /bin/true
             docker cp . input:/home/builder/package/
-            docker create --name output --volume /packages alpine:3.9 /bin/true
+            docker create --name output --volume /packages alpine:3.10 /bin/true
             docker cp sgerrand.rsa.pub output:/packages/
       - run:
           name: Build packages
           command: docker run --env RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" --env RSA_PRIVATE_KEY_NAME="sgerrand.rsa" --volumes-from input --volumes-from output sgerrand/alpine-abuild:3.9
       - run:
           name: Test package installation
-          command: docker run --volumes-from output alpine:3.9 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
+          command: docker run --volumes-from output alpine:3.10 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
       - run:
           name: Extract packages
           command: |


### PR DESCRIPTION
🚧 ⚠️ Still a work in progress 🚧 ⚠️ 

💁 Update the package dependencies to bump the version of `libgcc`. This should mitigate the effect of [CVE-2019-15847](https://nvd.nist.gov/vuln/detail/CVE-2019-15847) on this package.

Closes #127