### PR TITLE
Alpine Linux 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,16 +33,25 @@ jobs:
       - run:
           name: Create Docker volumes
           command: |
-            docker create --name input --volume /home/builder/package alpine:3.9 /bin/true
+            docker create --name input --volume /home/builder/package alpine:3.11 /bin/true
             docker cp . input:/home/builder/package/
-            docker create --name output --volume /packages alpine:3.9 /bin/true
+            docker create --name output --volume /packages alpine:3.11 /bin/true
             docker cp sgerrand.rsa.pub output:/packages/
       - run:
           name: Build packages
-          command: docker run --env RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" --env RSA_PRIVATE_KEY_NAME="sgerrand.rsa" --volumes-from input --volumes-from output sgerrand/alpine-abuild:3.9
+          command: |
+            docker run \
+              --env RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" \
+              --env RSA_PRIVATE_KEY_NAME="sgerrand.rsa" \
+              --volumes-from input \
+              --volumes-from output \
+              sgerrand/alpine-abuild:3.11
       - run:
           name: Test package installation
-          command: docker run --volumes-from output alpine:3.9 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
+          command: |
+            docker run \
+              --volumes-from output \
+              alpine:3.11 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
       - run:
           name: Extract packages
           command: |


### PR DESCRIPTION
💁 Alpine Linux 3.11 was [released on 2019-12-19](https://alpinelinux.org/posts/Alpine-3.11.0-released.html) and should be used as part of the build and test jobs.