### PR TITLE
glibc 2.31

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 
 pkgname="glibc"
-pkgver="2.30"
+pkgver="2.31"
 _pkgrel="0"
 pkgrel="0"
 pkgdesc="GNU C Library compatibility layer"
@@ -47,6 +47,6 @@ i18n() {
   cp -a "$srcdir"/usr/glibc-compat/share "$subpkgdir"/usr/glibc-compat
 }
 
-sha512sums="047827b2855c0dd62ba7f085dece3e4c38ec67f064c0f646566bb97035f69a1733571ce71584f07795a0c3014e80fa8811d50c7c35cccd19ee4c1d50f22bc552  glibc-bin-2.30-0-x86_64.tar.gz
+sha512sums="6462b5d5febe895d5e9a618b5d7659671d685602ced7a91e578bd8842ddf541f759d6a9ef113be11132b18142e2ea4c803822b63847022b01394499e68a92a66  glibc-bin-2.31-0-x86_64.tar.gz
 478bdd9f7da9e6453cca91ce0bd20eec031e7424e967696eb3947e3f21aa86067aaf614784b89a117279d8a939174498210eaaa2f277d3942d1ca7b4809d4b7e  nsswitch.conf
 2912f254f8eceed1f384a1035ad0f42f5506c609ec08c361e2c0093506724a6114732db1c67171c8561f25893c0dd5c0c1d62e8a726712216d9b45973585c9f7  ld.so.conf"


### PR DESCRIPTION
💁 These changes release [version 2.31](https://sourceware.org/ml/libc-announce/2020/msg00001.html) of the [GNU C Library](https://www.gnu.org/software/libc/) package.

Closes #132