### PR TITLE
Update glibc to 3.12

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 
 pkgname="glibc"
-pkgver="2.31"
+pkgver="2.32"
 _pkgrel="0"
 pkgrel="0"
 pkgdesc="GNU C Library compatibility layer"
@@ -47,6 +47,6 @@ i18n() {
   cp -a "$srcdir"/usr/glibc-compat/share "$subpkgdir"/usr/glibc-compat
 }
 
-sha512sums="6462b5d5febe895d5e9a618b5d7659671d685602ced7a91e578bd8842ddf541f759d6a9ef113be11132b18142e2ea4c803822b63847022b01394499e68a92a66  glibc-bin-2.31-0-x86_64.tar.gz
+sha512sums="dace2ea2acf8c4cf261f8e6d6aec2dcb8a265b004491d2fc163c5c882d479316ecd421e94a162486ea5d8ed61d36d7d87c5b236a96ff6ab84e509ecae0b12931  glibc-bin-2.32-0-x86_64.tar.gz
 478bdd9f7da9e6453cca91ce0bd20eec031e7424e967696eb3947e3f21aa86067aaf614784b89a117279d8a939174498210eaaa2f277d3942d1ca7b4809d4b7e  nsswitch.conf
 2912f254f8eceed1f384a1035ad0f42f5506c609ec08c361e2c0093506724a6114732db1c67171c8561f25893c0dd5c0c1d62e8a726712216d9b45973585c9f7  ld.so.conf"


### PR DESCRIPTION
💁 These changes release [version 2.32](https://sourceware.org/pipermail/libc-announce/2020/000029.html) of the [GNU C Library](https://www.gnu.org/software/libc/) package.

Closes #137