### PR TITLE
Update documentation to reference v2.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ See the [releases page](https://github.com/sgerrand/alpine-pkg-glibc/releases) f
 The current installation method for these packages is to pull them in using `wget` or `curl` and install the local file with `apk`:
 
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-2.31-r0.apk
-    apk add glibc-2.31-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk
+    apk add glibc-2.32-r0.apk
 
 ### Please Note
 
@@ -26,7 +26,7 @@ Any previous reference to `https://raw.githubusercontent.com/sgerrand/alpine-pkg
 
 You will need to generate your locale if you would like to use a specific one for your glibc application. You can do this by installing the `glibc-i18n` package and generating a locale using the `localedef` binary. An example for en_US.UTF-8 would be:
 
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-bin-2.31-r0.apk
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-i18n-2.31-r0.apk
-    apk add glibc-bin-2.31-r0.apk glibc-i18n-2.31-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-bin-2.32-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-i18n-2.32-r0.apk
+    apk add glibc-bin-2.32-r0.apk glibc-i18n-2.32-r0.apk
     /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8


### PR DESCRIPTION
💁 Related to #141 and needed before tagging this release.

Unfortunately the doctests have a 🐔 and 🥚 problem, in that they will fail on this branch until `2.32-r0` is tagged. I'll re-run them after that.