### PR TITLE
Update glibc to v2.35

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ jobs:
       - run:
           name: Create Docker volumes
           command: |
-            docker create --name input --volume /home/builder/package alpine:3.11 /bin/true
+            docker create --name input --volume /home/builder/package alpine:3.15 /bin/true
             docker cp . input:/home/builder/package/
-            docker create --name output --volume /packages alpine:3.11 /bin/true
+            docker create --name output --volume /packages alpine:3.15 /bin/true
             docker cp sgerrand.rsa.pub output:/packages/
       - run:
           name: Build packages
@@ -45,13 +45,13 @@ jobs:
               --env RSA_PRIVATE_KEY_NAME="sgerrand.rsa" \
               --volumes-from input \
               --volumes-from output \
-              sgerrand/alpine-abuild:3.11
+              sgerrand/alpine-abuild:3.15
       - run:
           name: Test package installation
           command: |
             docker run \
               --volumes-from output \
-              alpine:3.11 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
+              alpine:3.15 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
       - run:
           name: Extract packages
           command: |

--- a/APKBUILD
+++ b/APKBUILD
@@ -33,7 +33,7 @@ package() {
 }
 
 bin() {
-  depends="$pkgname libgcc"
+  depends="$pkgname libc6-compat libgcc"
   mkdir -p "$subpkgdir"/usr/glibc-compat
   cp -a "$srcdir"/usr/glibc-compat/bin "$subpkgdir"/usr/glibc-compat
   cp -a "$srcdir"/usr/glibc-compat/sbin "$subpkgdir"/usr/glibc-compat

--- a/APKBUILD
+++ b/APKBUILD
@@ -15,7 +15,7 @@ subpackages="$pkgname-bin $pkgname-dev $pkgname-i18n"
 triggers="$pkgname-bin.trigger=/lib:/usr/lib:/usr/glibc-compat/lib"
 
 package() {
-  mkdir -p "$pkgdir/lib" "$pkgdir/lib64" "$pkgdir/usr/glibc-compat/lib/locale"  "$pkgdir"/usr/glibc-compat/lib64 "$pkgdir"/etc
+  mkdir -p "$pkgdir/lib" "$pkgdir/usr/glibc-compat/lib/locale"  "$pkgdir"/usr/glibc-compat/lib64 "$pkgdir"/etc
   cp -a "$srcdir"/usr "$pkgdir"
   cp "$srcdir"/ld.so.conf "$pkgdir"/usr/glibc-compat/etc/ld.so.conf
   cp "$srcdir"/nsswitch.conf "$pkgdir"/etc/nsswitch.conf
@@ -28,7 +28,6 @@ package() {
   rm -rf "$pkgdir"/usr/glibc-compat/share
   rm -rf "$pkgdir"/usr/glibc-compat/var
   ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 ${pkgdir}/lib/ld-linux-x86-64.so.2
-  ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 ${pkgdir}/lib64/ld-linux-x86-64.so.2
   ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 ${pkgdir}/usr/glibc-compat/lib64/ld-linux-x86-64.so.2
   ln -s /usr/glibc-compat/etc/ld.so.cache ${pkgdir}/etc/ld.so.cache
 }

--- a/APKBUILD
+++ b/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 
 pkgname="glibc"
-pkgver="2.34"
+pkgver="2.35"
 _pkgrel="0"
 pkgrel="0"
 pkgdesc="GNU C Library compatibility layer"
@@ -47,6 +47,8 @@ i18n() {
   cp -a "$srcdir"/usr/glibc-compat/share "$subpkgdir"/usr/glibc-compat
 }
 
-sha512sums="77e772a8edd55812e94f99087ea2a2307ac48b09d58fe0bbcb41f9b9861ef3a15b177699e2e1fb7e49fdeb42c64c33b81c0fdf4d44e043cd9f54c72b93f40d98  glibc-bin-2.34-0-x86_64.tar.gz
+sha512sums="
+0aff0ec76f4d341957a792b8635c0770148eba9a5cb64f9bbd85228c14d9cb93c1a402063cab533a9f536f5f7be92c27bc5be8ed13c2b4f7aa416510c754d071  glibc-bin-2.35-0-x86_64.tar.gz
 478bdd9f7da9e6453cca91ce0bd20eec031e7424e967696eb3947e3f21aa86067aaf614784b89a117279d8a939174498210eaaa2f277d3942d1ca7b4809d4b7e  nsswitch.conf
-2912f254f8eceed1f384a1035ad0f42f5506c609ec08c361e2c0093506724a6114732db1c67171c8561f25893c0dd5c0c1d62e8a726712216d9b45973585c9f7  ld.so.conf"
+2912f254f8eceed1f384a1035ad0f42f5506c609ec08c361e2c0093506724a6114732db1c67171c8561f25893c0dd5c0c1d62e8a726712216d9b45973585c9f7  ld.so.conf
+"

--- a/APKBUILD
+++ b/APKBUILD
@@ -33,7 +33,7 @@ package() {
 }
 
 bin() {
-  depends="$pkgname libc6-compat libgcc"
+  depends="$pkgname bash libc6-compat libgcc"
   mkdir -p "$subpkgdir"/usr/glibc-compat
   cp -a "$srcdir"/usr/glibc-compat/bin "$subpkgdir"/usr/glibc-compat
   cp -a "$srcdir"/usr/glibc-compat/sbin "$subpkgdir"/usr/glibc-compat


### PR DESCRIPTION
💁 These changes release [version 2.35](https://sourceware.org/pipermail/libc-alpha/2022-February/136040.html) of the [GNU C Library](https://www.gnu.org/software/libc/) package.

Closes #170