### PR TITLE
Fully replace `libc6-compat` and `musl-utils`

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -12,7 +12,7 @@ license="LGPL"
 source="https://github.com/sgerrand/docker-glibc-builder/releases/download/$pkgver-$_pkgrel/glibc-bin-$pkgver-$_pkgrel-x86_64.tar.gz
 nsswitch.conf
 ld.so.conf"
-subpackages="$pkgname-bin $pkgname-dev $pkgname-i18n"
+subpackages="$pkgname-bin $pkgname-utils $pkgname-dev $pkgname-i18n"
 triggers="$pkgname-bin.trigger=/lib:/usr/lib:/usr/glibc-compat/lib"
 
 package() {
@@ -37,12 +37,26 @@ package() {
 }
 
 bin() {
+  pkgdesc="executable programs that come with glibc, installed to /usr/glibc-compat/"
   depends="$pkgname libgcc"
   depends="$depends bash" # shebang for ldd, sotrus, tzselect, xtrace
   depends="$depends perl" # shebang for mtrace
   mkdir -p "$subpkgdir"/usr/glibc-compat
   cp -a "$srcdir"/usr/glibc-compat/bin "$subpkgdir"/usr/glibc-compat
   cp -a "$srcdir"/usr/glibc-compat/sbin "$subpkgdir"/usr/glibc-compat
+}
+
+utils() {
+  pkgdesc="a replacement for musl-utils that uses the glibc versions of those utilities"
+  depends="$pkgname-bin"
+  provides="musl-utils"
+  conflicts="musl-utils"
+  mkdir -p "$subpkgdir"/usr/bin "$subpkgdir"/usr/sbin
+  ln -s /usr/glibc-compat/bin/getconf   "$subpkgdir"/usr/bin
+  ln -s /usr/glibc-compat/bin/getent    "$subpkgdir"/usr/bin
+  ln -s /usr/glibc-compat/bin/iconv     "$subpkgdir"/usr/bin
+  ln -s /usr/glibc-compat/bin/ldd       "$subpkgdir"/usr/bin
+  ln -s /usr/glibc-compat/sbin/ldconfig "$subpkgdir"/usr/sbin
 }
 
 i18n() {

--- a/APKBUILD
+++ b/APKBUILD
@@ -37,7 +37,9 @@ package() {
 }
 
 bin() {
-  depends="$pkgname bash libgcc"
+  depends="$pkgname libgcc"
+  depends="$depends bash" # shebang for ldd, sotrus, tzselect, xtrace
+  depends="$depends perl" # shebang for mtrace
   mkdir -p "$subpkgdir"/usr/glibc-compat
   cp -a "$srcdir"/usr/glibc-compat/bin "$subpkgdir"/usr/glibc-compat
   cp -a "$srcdir"/usr/glibc-compat/sbin "$subpkgdir"/usr/glibc-compat

--- a/APKBUILD
+++ b/APKBUILD
@@ -3,7 +3,7 @@
 pkgname="glibc"
 pkgver="2.35"
 _pkgrel="0"
-pkgrel="0"
+pkgrel="1"
 pkgdesc="GNU C Library compatibility layer"
 options="lib64"
 arch="x86_64"

--- a/APKBUILD
+++ b/APKBUILD
@@ -5,6 +5,7 @@ pkgver="2.35"
 _pkgrel="0"
 pkgrel="0"
 pkgdesc="GNU C Library compatibility layer"
+options="lib64"
 arch="x86_64"
 url="https://github.com/sgerrand/alpine-pkg-glibc"
 license="LGPL"
@@ -15,7 +16,9 @@ subpackages="$pkgname-bin $pkgname-dev $pkgname-i18n"
 triggers="$pkgname-bin.trigger=/lib:/usr/lib:/usr/glibc-compat/lib"
 
 package() {
-  mkdir -p "$pkgdir/lib" "$pkgdir/usr/glibc-compat/lib/locale"  "$pkgdir"/usr/glibc-compat/lib64 "$pkgdir"/etc
+  provides="libc6-compat"
+  conflicts="libc6-compat"
+  mkdir -p "$pkgdir/lib" "$pkgdir/lib64" "$pkgdir/usr/glibc-compat/lib/locale"  "$pkgdir"/usr/glibc-compat/lib64 "$pkgdir"/etc
   cp -a "$srcdir"/usr "$pkgdir"
   cp "$srcdir"/ld.so.conf "$pkgdir"/usr/glibc-compat/etc/ld.so.conf
   cp "$srcdir"/nsswitch.conf "$pkgdir"/etc/nsswitch.conf
@@ -28,12 +31,13 @@ package() {
   rm -rf "$pkgdir"/usr/glibc-compat/share
   rm -rf "$pkgdir"/usr/glibc-compat/var
   ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 ${pkgdir}/lib/ld-linux-x86-64.so.2
+  ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 ${pkgdir}/lib64/ld-linux-x86-64.so.2
   ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 ${pkgdir}/usr/glibc-compat/lib64/ld-linux-x86-64.so.2
   ln -s /usr/glibc-compat/etc/ld.so.cache ${pkgdir}/etc/ld.so.cache
 }
 
 bin() {
-  depends="$pkgname bash libc6-compat libgcc"
+  depends="$pkgname bash libgcc"
   mkdir -p "$subpkgdir"/usr/glibc-compat
   cp -a "$srcdir"/usr/glibc-compat/bin "$subpkgdir"/usr/glibc-compat
   cp -a "$srcdir"/usr/glibc-compat/sbin "$subpkgdir"/usr/glibc-compat


### PR DESCRIPTION
When upgrading 2.34→2.35, https://github.com/sgerrand/alpine-pkg-glibc/pull/171 also made the change that it drops the `/lib64/ld-linux-x86-64.so.2` symlink and instead depend on `libc6-compat`'s version of that symlink.

This broke [us](https://github.com/emissary-ingress/emissary/pull/4245), as `/lib/ld-linux-x86-64.so.2` was going for glibc, while `/lib64/ld-linux-x86-64.so.2` was going for musl, and that managed to confuse our binary.

----

Dropping the symlink was justified by `ERROR: glibc*: Packages must not put anything under /lib64, use /lib instead`; but `man apkbuild` tells us about the `lib64` value for `options=`: 

> Specifies that the package installs files under `/lib64` or `/usr/lib64` and that the test for those directories should be skipped.  This is discouraged and should only be used for packages providing compatibility for GNU libc.

That's exactly the case for us! So say `options="lib64"` and add the symlink back. Since this means that we file-conflict with `libc6-compat`, explicitly declare that and say `conflicts="libc6-compat"`.

----

What does `libc6-compat` do, what are the consequences of not being able to install both it and `glibc` at the same time? It adds glibc binary compatibility to musl, allowing binaries linked against glibc to use Alpine's native musl. So it doesn't really make sense to have both `glibc` and `libc6-compat` to be installed at once; if you have `glibc` installed that's a strong indicator that you want glibc-linked binaries to use the actual glibc and not musl. So the above `conflicts=` is probably the right thing. At the same time, the intent of `libc6-compat` can be written as "I'd like to be able to run binaries that are linked against glibc", so also say `provides="libc6-compat"`.

The commit that added `glibc-bin`'s dependency on `libc6-compat` (39878629cbf803bc70323f35dfeb674da9a5c0ac) said "This package not being installed is a very common cause of reported user errors." I'm not sure what those reported user errors are; that claim doesn't make much sense to me.

----

I also added a `glibc-utils` counterpart to `musl-utils`; it just symlinks programs from `glibc-bin`'s `/usr/glibc-compat` in to `/usr`.

----

I also gave `glibc-bin` a dependency on `perl`, as `mtrace` uses perl in its shebang.

----

I have not actually built or tested this.