### PR TITLE
Remove `nsswitch.conf`

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -9,7 +9,6 @@ arch="x86_64"
 url="https://github.com/sgerrand/alpine-pkg-glibc"
 license="LGPL"
 source="https://github.com/sgerrand/docker-glibc-builder/releases/download/$pkgver-$_pkgrel/glibc-bin-$pkgver-$_pkgrel-x86_64.tar.gz
-nsswitch.conf
 ld.so.conf"
 subpackages="$pkgname-bin $pkgname-dev $pkgname-i18n"
 triggers="$pkgname-bin.trigger=/lib:/usr/lib:/usr/glibc-compat/lib"
@@ -18,7 +17,6 @@ package() {
   mkdir -p "$pkgdir/lib" "$pkgdir/usr/glibc-compat/lib/locale"  "$pkgdir"/usr/glibc-compat/lib64 "$pkgdir"/etc
   cp -a "$srcdir"/usr "$pkgdir"
   cp "$srcdir"/ld.so.conf "$pkgdir"/usr/glibc-compat/etc/ld.so.conf
-  cp "$srcdir"/nsswitch.conf "$pkgdir"/etc/nsswitch.conf
   rm "$pkgdir"/usr/glibc-compat/etc/rpc
   rm -rf "$pkgdir"/usr/glibc-compat/bin
   rm -rf "$pkgdir"/usr/glibc-compat/sbin
@@ -48,6 +46,5 @@ i18n() {
 
 sha512sums="
 0aff0ec76f4d341957a792b8635c0770148eba9a5cb64f9bbd85228c14d9cb93c1a402063cab533a9f536f5f7be92c27bc5be8ed13c2b4f7aa416510c754d071  glibc-bin-2.35-0-x86_64.tar.gz
-478bdd9f7da9e6453cca91ce0bd20eec031e7424e967696eb3947e3f21aa86067aaf614784b89a117279d8a939174498210eaaa2f277d3942d1ca7b4809d4b7e  nsswitch.conf
 2912f254f8eceed1f384a1035ad0f42f5506c609ec08c361e2c0093506724a6114732db1c67171c8561f25893c0dd5c0c1d62e8a726712216d9b45973585c9f7  ld.so.conf
 "

--- a/nsswitch.conf
+++ b/nsswitch.conf
@@ -1,1 +1,0 @@
-hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4


### PR DESCRIPTION
💁 The `nsswitch.conf` file is now present in the `alpine-baselayout-data` package as of https://git.alpinelinux.org/aports/commit/?h=3.16-stable&id=348653a9ba0701e8e968b3344e72313a9ef334e4. The contents of the 2 files are broadly similar enough, i.e. that the precedence is for file based DNS entries over the network so that should be good enough for general usage by glibc based apps.

Fixes #185