### PR TITLE
Release 2.35-r1

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -3,7 +3,7 @@
 pkgname="glibc"
 pkgver="2.35"
 _pkgrel="0"
-pkgrel="0"
+pkgrel="1"
 pkgdesc="GNU C Library compatibility layer"
 arch="x86_64"
 url="https://github.com/sgerrand/alpine-pkg-glibc"

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ See the [releases page](https://github.com/sgerrand/alpine-pkg-glibc/releases) f
 The current installation method for these packages is to pull them in using `wget` or `curl` and install the local file with `apk`:
 
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk
-    apk add glibc-2.35-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk
+    apk add glibc-2.35-r1.apk
 
 ### Please Note
 
@@ -26,7 +26,7 @@ Any previous reference to `https://raw.githubusercontent.com/sgerrand/alpine-pkg
 
 You will need to generate your locale if you would like to use a specific one for your glibc application. You can do this by installing the `glibc-i18n` package and generating a locale using the `localedef` binary. An example for en_US.UTF-8 would be:
 
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-bin-2.35-r0.apk
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-i18n-2.35-r0.apk
-    apk add glibc-bin-2.35-r0.apk glibc-i18n-2.35-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-bin-2.35-r1.apk
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-i18n-2.35-r1.apk
+    apk add glibc-bin-2.35-r1.apk glibc-i18n-2.35-r1.apk
     /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8


### PR DESCRIPTION
💁 These changes bump the release number of this package to 2.35-r1 in order to release the changes in #195 and resolve the issues encountered by downstream consumers.