### PR TITLE
Prefer `go install` for `ghr`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ references:
   upload-packages: &upload-packages
     run:
       command: apk add --no-cache git openssh-client
-      name: Install dependencies of go get
+      name: Install dependencies of go install
   upload-ghr: &upload-ghr
     run:
-      command: go get github.com/tcnksm/ghr
+      command: go install github.com/tcnksm/ghr@latest
       name: Install ghr executable
 jobs:
   build:


### PR DESCRIPTION
💁 Modern go versions have hard deprecated `go get` outside of modules:
```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```
This change updates `go get` to `go install` for installing `ghr`.