### PR TITLE
Add issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: triage
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behaviour:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behaviour**
+A clear and concise description of what you expected to happen.
+
+**Dockerfile**
+How to build the application that is the source of this bug report as a `Dockerfile`. This needs to be reproducible to investigate the bug.
+
+**Environment (please complete the following information):**
+ - Alpine Linux version: [e.g. 3.18]
+ - Emulated? [e.g. yes]
+ - Emulation [e.g. Docker]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Providing a template for bug reports should improve the quality of contextual information supplied by users and should lead to faster resolution times due to reduced back-and-forth discussions required to extract this information afterwards.